### PR TITLE
Add optional scope to XUIElement properties 

### DIFF
--- a/RapidA11y/NSObject+Rapid.swift
+++ b/RapidA11y/NSObject+Rapid.swift
@@ -25,12 +25,7 @@ extension NSObject: RapidControlIdentifiable {
     }
 
     @discardableResult
-    public func applyProperties(_ controlTag: Int = 0, classOverride controlType: NSObject.Type? = nil) -> RapidControlInformation {
-        let selfType = controlType ?? type(of: self)
-        var properties = selfType.accessibilityProperties
-        properties.index = controlTag
-        properties.type = selfType
-
+    public func applyProperties(_ properties: RapidControlInformation) -> RapidControlInformation {
         // only 3 controls supported by UIAccessibilityIdentification
         if let identifiableViewSelf = self as? UIView {
             identifiableViewSelf.accessibilityIdentifier = properties.identifier

--- a/RapidA11y/Rapid.swift
+++ b/RapidA11y/Rapid.swift
@@ -29,7 +29,7 @@ public protocol RapidIdentifiable {
 
 public protocol RapidControlIdentifiable: Hashable {
     static var accessibilityProperties: RapidControlInformation { get }
-    func applyProperties(_ controlTag: Int, classOverride controlType: NSObject.Type?) -> RapidControlInformation
+    func applyProperties(_ properties: RapidControlInformation) -> RapidControlInformation
 }
 
 public enum AccessibilityControlType {

--- a/RapidA11y/RapidControlInformation.swift
+++ b/RapidA11y/RapidControlInformation.swift
@@ -23,13 +23,16 @@ public struct RapidControlInformation: Hashable {
     public static let viewIdentifierSuffix: String = "_view_a11yID"
 
     public var identifier: String {
-        return "\(type)_\(index)_control_a11yID"
+        let scope = self.scope ?? ""
+
+        return "\(type)_\(index)_\(scope)_control_a11yID"
     }
 
     public var index: Int = 0
     public var rapidType: AccessibilityControlType = .any
     public var traits: UIAccessibilityTraits = UIAccessibilityTraitNone
     public var type: NSObject.Type
+    public var scope: String?
 
     public var hashValue: Int {
         return identifier.hash

--- a/RapidA11y/UIViewController+Rapid.swift
+++ b/RapidA11y/UIViewController+Rapid.swift
@@ -34,8 +34,11 @@ extension UIViewController: RapidIdentifiable {
             return
         }
 
-        _ = controls.enumerated().map { index, control in
-            control.applyProperties(index, classOverride: controlsInformation[index].type)
+        _ = controls.enumerated().map {
+            let index = $0.offset
+            let control = $0.element
+
+            control.applyProperties(controlsInformation[index])
         }
     }
 }

--- a/RapidA11y/UIViewController+Rapid.swift
+++ b/RapidA11y/UIViewController+Rapid.swift
@@ -34,10 +34,7 @@ extension UIViewController: RapidIdentifiable {
             return
         }
 
-        _ = controls.enumerated().map {
-            let index = $0.offset
-            let control = $0.element
-
+        _ = controls.enumerated().map { index, control in
             control.applyProperties(controlsInformation[index])
         }
     }


### PR DESCRIPTION
To help avoid "multiple matches found" issue when multiple view controllers in the hierarchy contain the same types of controls.